### PR TITLE
Add support for gen_test conversion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as readme:
 
 setup(
     name="tornado-async-transformer",
-    version="0.1.7",
+    version="0.2.0",
     description="libcst transformer and codemod for updating tornado @gen.coroutine syntax to python3.5+ native async/await",
     url="https://github.com/zhammer/tornado-async-transformer",
     packages=find_packages(exclude=["tests", "demo_site"]),

--- a/tests/test_cases/gen_test/after.py
+++ b/tests/test_cases/gen_test/after.py
@@ -1,0 +1,17 @@
+"""
+A tornado gen_test using @gen_test decorator.
+"""
+
+from tornado.testing import gen_test, AsyncHTTPTestCase
+
+from my_app import make_application
+
+
+class TestMyTornadoApp(AsyncHTTPTestCase):
+    def get_app(self):
+        return make_application()
+
+    @gen_test
+    async def test_ping_route(self):
+        response = await self.fetch("/ping")
+        assert response.body == b"pong"

--- a/tests/test_cases/gen_test/before.py
+++ b/tests/test_cases/gen_test/before.py
@@ -1,0 +1,17 @@
+"""
+A tornado gen_test using @gen_test decorator.
+"""
+
+from tornado.testing import gen_test, AsyncHTTPTestCase
+
+from my_app import make_application
+
+
+class TestMyTornadoApp(AsyncHTTPTestCase):
+    def get_app(self):
+        return make_application()
+
+    @gen_test
+    def test_ping_route(self):
+        response = yield self.fetch("/ping")
+        assert response.body == b"pong"

--- a/tests/test_cases/testing_gen_test/after.py
+++ b/tests/test_cases/testing_gen_test/after.py
@@ -1,0 +1,17 @@
+"""
+A tornado gen_test using @testing.gen_test decorator.
+"""
+
+from tornado import testing
+
+from my_app import make_application
+
+
+class TestMyTornadoApp(testing.AsyncHTTPTestCase):
+    def get_app(self):
+        return make_application()
+
+    @testing.gen_test
+    async def test_ping_route(self):
+        response = await self.fetch("/ping")
+        assert response.body == b"pong"

--- a/tests/test_cases/testing_gen_test/before.py
+++ b/tests/test_cases/testing_gen_test/before.py
@@ -1,0 +1,17 @@
+"""
+A tornado gen_test using @testing.gen_test decorator.
+"""
+
+from tornado import testing
+
+from my_app import make_application
+
+
+class TestMyTornadoApp(testing.AsyncHTTPTestCase):
+    def get_app(self):
+        return make_application()
+
+    @testing.gen_test
+    def test_ping_route(self):
+        response = yield self.fetch("/ping")
+        assert response.body == b"pong"

--- a/tests/test_cases/tornado_testing_gen_test/after.py
+++ b/tests/test_cases/tornado_testing_gen_test/after.py
@@ -1,0 +1,17 @@
+"""
+A tornado gen_test using @tornado.testing.gen_test decorator.
+"""
+
+import tornado
+
+from my_app import make_application
+
+
+class TestMyTornadoApp(tornado.testing.AsyncHTTPTestCase):
+    def get_app(self):
+        return make_application()
+
+    @tornado.testing.gen_test
+    async def test_ping_route(self):
+        response = await self.fetch("/ping")
+        assert response.body == b"pong"

--- a/tests/test_cases/tornado_testing_gen_test/before.py
+++ b/tests/test_cases/tornado_testing_gen_test/before.py
@@ -1,0 +1,17 @@
+"""
+A tornado gen_test using @tornado.testing.gen_test decorator.
+"""
+
+import tornado
+
+from my_app import make_application
+
+
+class TestMyTornadoApp(tornado.testing.AsyncHTTPTestCase):
+    def get_app(self):
+        return make_application()
+
+    @tornado.testing.gen_test
+    def test_ping_route(self):
+        response = yield self.fetch("/ping")
+        assert response.body == b"pong"

--- a/tests/test_cases/tornado_testing_gen_test_already_async/after.py
+++ b/tests/test_cases/tornado_testing_gen_test_already_async/after.py
@@ -1,0 +1,22 @@
+"""
+A tornado gen_test using @tornado.testing.gen_test decorator that is already
+an async function. Function should not be modified.
+"""
+
+# This is a pretty contrived example to confirm these tests won't have yields changed to awaits.
+import some_experimental_pytest_decorator_that_allows_yielding_in_test_flow
+import tornado
+
+from my_app import make_application
+
+
+class TestMyTornadoApp(tornado.testing.AsyncHTTPTestCase):
+    def get_app(self):
+        return make_application()
+
+    @tornado.testing.gen_test
+    @some_experimental_pytest_decorator_that_allows_yielding_in_test_flow(b"pong")
+    async def test_ping_route(self, yielder):
+        response = await self.fetch("/ping")
+        expected_response = yield yielder()
+        assert response.body == expected_response

--- a/tests/test_cases/tornado_testing_gen_test_already_async/before.py
+++ b/tests/test_cases/tornado_testing_gen_test_already_async/before.py
@@ -1,0 +1,22 @@
+"""
+A tornado gen_test using @tornado.testing.gen_test decorator that is already
+an async function. Function should not be modified.
+"""
+
+# This is a pretty contrived example to confirm these tests won't have yields changed to awaits.
+import some_experimental_pytest_decorator_that_allows_yielding_in_test_flow
+import tornado
+
+from my_app import make_application
+
+
+class TestMyTornadoApp(tornado.testing.AsyncHTTPTestCase):
+    def get_app(self):
+        return make_application()
+
+    @tornado.testing.gen_test
+    @some_experimental_pytest_decorator_that_allows_yielding_in_test_flow(b"pong")
+    async def test_ping_route(self, yielder):
+        response = await self.fetch("/ping")
+        expected_response = yield yielder()
+        assert response.body == expected_response

--- a/tornado_async_transformer/tornado_async_transformer.py
+++ b/tornado_async_transformer/tornado_async_transformer.py
@@ -218,6 +218,10 @@ class TornadoAsyncTransformer(cst.CSTTransformer):
 
     @staticmethod
     def is_coroutine(function_def: cst.FunctionDef) -> bool:
+        # function already uses async def
+        if not function_def.asynchronous is None:
+            return False
+
         return any(
             (
                 TornadoAsyncTransformer.is_coroutine_decorator(

--- a/tornado_async_transformer/tornado_async_transformer.py
+++ b/tornado_async_transformer/tornado_async_transformer.py
@@ -78,7 +78,7 @@ class TornadoAsyncTransformer(cst.CSTTransformer):
             decorators=[
                 decorator
                 for decorator in updated_node.decorators
-                if not self.is_coroutine_decorator(decorator)
+                if not self.is_coroutine_decorator(decorator, include_gen_test=False)
             ],
             asynchronous=cst.Asynchronous(),
         )
@@ -198,17 +198,31 @@ class TornadoAsyncTransformer(cst.CSTTransformer):
         )
 
     @staticmethod
-    def is_coroutine_decorator(decorator: cst.Decorator) -> bool:
+    def is_coroutine_decorator(
+        decorator: cst.Decorator, include_gen_test: bool
+    ) -> bool:
+        coroutine_decorators = [
+            ["tornado", "gen", "coroutine"],
+            ["gen", "coroutine"],
+            ["coroutine"],
+        ]
+        if include_gen_test:
+            coroutine_decorators += [
+                ["tornado", "testing", "gen_test"],
+                ["testing", "gen_test"],
+                ["gen_test"],
+            ]
         return name_or_attribute_matches_one_of(
-            decorator.decorator,
-            [["tornado", "gen", "coroutine"], ["gen", "coroutine"], ["coroutine"]],
+            decorator.decorator, coroutine_decorators
         )
 
     @staticmethod
     def is_coroutine(function_def: cst.FunctionDef) -> bool:
         return any(
             (
-                TornadoAsyncTransformer.is_coroutine_decorator(decorator)
+                TornadoAsyncTransformer.is_coroutine_decorator(
+                    decorator, include_gen_test=True
+                )
                 for decorator in function_def.decorators
             )
         )


### PR DESCRIPTION
this adds some mess with the `include_gen_test` kwarg for `is_coroutine_decorator`. also, in `is_coroutine`, i think we should raise an error if the function is a `gen.coroutine` _and_ is already `async` (unless that is allowed by tornado, which i can check). 